### PR TITLE
Fix "Invalid Filename" errors

### DIFF
--- a/TSParser.py
+++ b/TSParser.py
@@ -577,11 +577,11 @@ def Main():
 
     if (opts.filename == ""):
         filename = getFilename()
+    else:
+        filename = opts.filename
     
     if (filename == ""):
         return
-    else:
-        filename = opts.filename
 
     print filename
     filehandle = open(filename,'rb')


### PR DESCRIPTION
Currently, running the program and using the GUI to select a file results in the following error:

```
IOError: [Errno 22] invalid mode ('rb') or filename: ''
```

This seems to be caused by an incorrectly placed `else` statement, which I have moved.
